### PR TITLE
add build functionality	without	docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+##### IDES  #######
 .vscode/
+.idea/
+##### BUILD ARTIFACTS #####
 build/
+/local_root/**/*
+/External/**/*
+#### RESOURCES #####
 misc/images
 misc/input/*
 !misc/input/receipt_1.jpg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,12 @@
 #                             Configuration                              #
 ##########################################################################
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.2...3.5)
 project(ocr-receipt VERSION 1.0.0)
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+	set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
@@ -11,21 +15,41 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set(EXTRA_COMPILE_FLAGS "-Wall -Werror")
 set(BINARY ${CMAKE_PROJECT_NAME})
 set(TEST ${CMAKE_PROJECT_NAME}-test)
+option(DOCKERLESS_BUILD "Loads a different set of configurations  and build processes depending on wether or not docker is going to be used" OFF)
+
 
 find_package(Boost 1.74.0 REQUIRED COMPONENTS filesystem locale program_options system)
 include_directories(${Boost_INCLUDE_DIR})
-
-find_package(Leptonica 1.82.0 REQUIRED)
-include_directories(${Leptonica_INCLUDE_DIRS})
-
-find_package(Tesseract 5.1.0 REQUIRED)
-include_directories(${Tesseract_INCLUDE_DIRS})
 
 find_package(OpenCV 4.5.4 REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 find_package(PythonLibs 3.10.4 REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
+
+############################################################
+#        Handle Leptonica and Tesseract Libraries          #
+#        if they are found we carry else we need to        #
+#        build them statically at configure time so        #
+#        that they are accessible at build time            #
+#        this is handled by a seperate cmake file          #
+#        which is included only if one of the libraries    #
+#        is non existent or the DOCKERLESS_BUILD Option    #
+#        is set to ON.                                     #
+############################################################
+find_package(Leptonica 1.82.0 QUIET) # DO NOT SET THIS TO REQUIRED
+find_package(Tesseract 5.1.0 QUIET)  # DO NOT SET THIS TO REQUIRED
+
+if(NOT Leptonica_FOUND OR NOT Tesseract_FOUND OR DOCKERLESS_BUILD)
+	message(STATUS "Building in Docker-less Mode")
+	include(TesseractLeptExternalStatics.cmake)
+else ()
+	include_directories(${Leptonica_INCLUDE_DIRS})
+	include_directories(${Tesseract_INCLUDE_DIRS})
+endif ()
+
+
+
 
 add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
@@ -39,7 +63,24 @@ set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 file(GLOB_RECURSE SOURCES ${SOURCE_DIR}/*.cpp)
 
 add_executable(${BINARY} ${SOURCES} ${INCLUDES} main.cpp)
-target_link_libraries(${BINARY} ${Boost_LIBRARIES} ${Tesseract_LIBRARIES} ${Leptonica_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES})
+if(EXTERNAL_STATIC_BUILD_TRIGGERED)
+
+
+	target_link_libraries(${BINARY} ${Boost_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES}  ${EXTRA_IMAGES_DYNAMIC_LIBRARIES} ${Tesseract_STATICLIB_TARGET} ${Leptonica_STATICLIB_TARGET})
+
+	if (DEFINED TESSDATA_DIR)
+		message(WARNING "    ==================================================================================================\n"
+				"    TESSDATA_PREFIX env Variable must be set to ${TESSDATA_DIR}\n"
+				"    Export this variable manually or set it persistently in a .bashrc or equivalent.\n"
+				"    ==================================================================================================\n"
+		)
+	endif ()
+
+else ()
+	target_link_libraries(${BINARY} ${Boost_LIBRARIES} ${Tesseract_LIBRARIES} ${Leptonica_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES})
+endif ()
+
+
 
 ##########################################################################
 #                               Unit Tests                               #
@@ -59,6 +100,9 @@ set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
 file(GLOB_RECURSE SOURCES_TEST ${TEST_DIR}/*.cpp)
 
 add_executable(${TEST} ${SOURCES} ${SOURCES_TEST} ${INCLUDES})
-target_link_libraries(${TEST} gtest_main ${Boost_LIBRARIES} ${Tesseract_LIBRARIES} ${Leptonica_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES})
-
+if(EXTERNAL_STATIC_BUILD_TRIGGERED)
+	target_link_libraries(${TEST} gtest_main ${Boost_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES} ${EXTRA_IMAGES_DYNAMIC_LIBRARIES} ${Tesseract_STATICLIB_TARGET} ${Leptonica_STATICLIB_TARGET})
+else ()
+	target_link_libraries(${TEST} gtest_main ${Boost_LIBRARIES} ${Tesseract_LIBRARIES} ${Leptonica_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES})
+endif ()
 gtest_discover_tests(${TEST})

--- a/README.md
+++ b/README.md
@@ -60,15 +60,78 @@ $ ./ocr-receipt -c ../misc/config.json -i ../misc/input/receipt_2.jpg --json
 
 ## Requirements
 
-The project itself is automatically built inside a Docker container based on following dependencies:
+### General 
 
-- Ubuntu 22.04
-- Tesseract 5.1.0
+- OpenCV 4.5.4
 - EasyOCR 1.5.0
 - Boost 1.74.0
-- OpenCV 4.5.4
+
+### Dependencies for Building with Docker (Optional)
+The project itself is automatically built inside a Docker container based on following dependencies:
+
+- Linux Based Distribution
+- Tesseract 5.1.0
+- Leptonica 1.82.0
+- Docker 
+
+### Dependencies when opting for Build without Docker (Optional)
+
+- Curl
+- Cmake 3.2.0
+- CXX Compiler
+- Git
+- Libarchive
+- Libpng
+- Libjpeg
+- Libgif
+- Libtiff
+- zlib
+- libwebp (webp)
+- libjp2k (openjpeg or JPEG 2000)
+
+Leptonica and Tesseract are not needed in this case since they will be fetched
+and compiled statically by the build script.
 
 ## Setup
+
+### Without Docker
+After cloning the repository go into the main project root and run the following :
+
+#### Configure
+```shell
+mkdir build \
+cd build 
+```
+
+```shell
+cmake ..
+```
+this will trigger a docker-independent build only if Tesseract and Leptonica are not available
+to force a static linkage of both libraries anyways, run the following instead : 
+
+```shell
+cmake -DDOCKERLESS_BUILD ..
+```
+The build script will fetch needed leptonica and tesseract libraries and link statically
+
+#### Build 
+
+```shell
+cmake --build --parallel ${nproc} ..
+```
+The binaries can then be found under the "build" folder
+
+#### Run Unit Tests
+
+```shell
+ctest
+```
+#### set TESSDATA_PREFIX
+
+The build script automatically fetches TESSDATA learningdata and provides information on where it is
+after the configuration step . Please follow this for a proper execution of the software
+
+### With Docker
 
 Build the image:
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ Total Test time (real) =  23.33 sec
 
 Perform character recognition on [one of the input images](https://github.com/cfanatic/ocr-receipt/blob/master/misc/input/receipt_2.jpg) from the `misc/input/` folder:
 
+### Without Docker
+
+Inside the build folder under the projects root . run the following
+
+```shell
+./ocr-receipt -c ../misc/config.json -i ../misc/input/receipt_2.jpg
+```
+
+
+### With Docker
+
 ```text
 docker exec -it ocr-receipt ./ocr-receipt -c ../misc/config.json -i ../misc/input/receipt_2.jpg
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The build script will fetch needed leptonica and tesseract libraries and link st
 #### Build 
 
 ```shell
-cmake --build --parallel ${nproc} ..
+cmake --build . --parallel ${nproc}
 ```
 The binaries can then be found under the "build" folder
 

--- a/TesseractLeptExternalStatics.cmake
+++ b/TesseractLeptExternalStatics.cmake
@@ -252,6 +252,3 @@ ExternalProject_Add(tesseract-traineddata
 ##########################################################################
 set(Tesseract_STATICLIB_TARGET tesseract)
 set(Leptonica_STATICLIB_TARGET leptonica)
-##########################################################################
-#                 Set TESSDATA_PREFIX                                    #
-##########################################################################

--- a/TesseractLeptExternalStatics.cmake
+++ b/TesseractLeptExternalStatics.cmake
@@ -1,0 +1,257 @@
+include(FetchContent)
+include(ExternalProject)
+include(ProcessorCount)
+
+
+set(EXTERNAL_STATIC_BUILD_TRIGGERED ON CACHE BOOL "" FORCE)
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
+#######################################################################
+#              Set Path Variables                                     #
+#######################################################################
+set(EXTERNAL_LIBS_DIR "${CMAKE_SOURCE_DIR}/External")
+set(LEPTONICA_SRC_DIR "${EXTERNAL_LIBS_DIR}/leptonica")
+set(TESSERACT_SRC_DIR "${EXTERNAL_LIBS_DIR}/tesseract")
+set(LOCAL_FAKEROOT_DIR "${CMAKE_SOURCE_DIR}/local_root")
+set(LOCAL_FAKEROOT_INSTALL_PREFIX "${LOCAL_FAKEROOT_DIR}/usr")
+set(LOCAL_FAKEROOT_INSTALL_INCLUDE_DIR "${LOCAL_FAKEROOT_INSTALL_PREFIX}/include")
+set(LOCAL_FAKEROOT_INSTALL_SHARE_DIR "${LOCAL_FAKEROOT_INSTALL_PREFIX}/local/share")
+set(LOCAL_FAKEROOT_INSTALL_LIBRARY_DIR "${LOCAL_FAKEROOT_INSTALL_PREFIX}/lib")
+set(TESSDATA_DIR "${LOCAL_FAKEROOT_INSTALL_SHARE_DIR}/tessdata")
+
+include_directories(${LOCAL_FAKEROOT_INSTALL_INCLUDE_DIR})
+
+#######################################################################
+#              We need  CURL and LibArchive                           #
+#######################################################################
+find_package(CURL)
+find_package(LibArchive)
+##################################################################################
+#                                                                                #
+#        Section Imported from Leptonica CMake . we need it to link              #
+#        Tesseract to leptonica statically without issues                        #
+#                                                                                #
+#                                                                                #
+##################################################################################
+find_package(GIF)
+find_package(JPEG)
+find_package(PNG)
+find_package(TIFF)
+find_package(ZLIB)
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(WEBP libwebp QUIET)
+    pkg_check_modules(WEBPMUX libwebpmux>=${MINIMUM_WEBPMUX_VERSION} QUIET)
+    pkg_check_modules(JP2K libopenjp2>=2.0 QUIET)
+endif()
+if(NOT WEBP)
+    find_path(WEBP_INCLUDE_DIR /webp/decode.h)
+    find_library(WEBP_LIBRARY NAMES webp)
+    if (WEBP_INCLUDE_DIR AND WEBP_LIBRARY)
+        set(WEBP 1)
+        set(WEBP_FOUND TRUE)
+        set(WEBP_LIBRARIES ${WEBP_LIBRARY})
+        set(WEBP_INCLUDE_DIRS ${WEBP_INCLUDE_DIR})
+    endif()
+endif()
+if(NOT WEBPMUX)
+    find_path(WEBPMUX_INCLUDE_DIR /webp/mux.h)
+    #TODO:  check minimal required version
+    if(NOT WEBPMUX_INCLUDE_DIR)
+        message(STATUS "Can not find: /webp/mux.h")
+    endif()
+    if(NOT "${WEBPMUX_INCLUDE_DIR}" STREQUAL "${WEBP_INCLUDE_DIR}")
+        set(WEBP_INCLUDE_DIRS ${WEBP_INCLUDE_DIRS} ${WEBPMUX_INCLUDE_DIR})
+    endif()
+    find_library(WEBPMUX_LIBRARY NAMES webpmux)
+    if (WEBPMUX_INCLUDE_DIR AND WEBPMUX_LIBRARY)
+        set(WEBPMUX 1)
+        set(HAVE_LIBWEBP_ANIM 1)
+        set(WEBPMUX_FOUND TRUE)
+        set(WEBP_LIBRARIES ${WEBP_LIBRARIES} ${WEBPMUX_LIBRARY})
+    endif()
+endif()
+if(NOT JP2K)
+    find_path(JP2K_INCLUDE_DIR /openjpeg-2.3/openjpeg.h)
+    find_library(JP2K_LIBRARY NAMES openjp2)
+    if (JP2K_INCLUDE_DIR AND JP2K_LIBRARY)
+        set(JP2K 1)
+        set(JP2K_FOUND TRUE)
+        set(JP2K_LIBRARIES ${JP2K_LIBRARY})
+        set(JP2K_INCLUDE_DIRS ${JP2K_INCLUDE_DIR})
+        set(HAVE_LIBJP2K 1)
+    endif()
+endif()
+if(NOT JP2K)
+    find_path(JP2K_INCLUDE_DIR /openjpeg-2.4/openjpeg.h)
+    find_library(JP2K_LIBRARY NAMES openjp2)
+    if (JP2K_INCLUDE_DIR AND JP2K_LIBRARY)
+        set(JP2K 1)
+        set(JP2K_FOUND TRUE)
+        set(JP2K_LIBRARIES ${JP2K_LIBRARY})
+        set(JP2K_INCLUDE_DIRS ${JP2K_INCLUDE_DIR})
+        set(HAVE_LIBJP2K 1)
+    endif()
+endif()
+
+#######################################################################
+#              END OF FOREIGN LEPTONICA SECTION IMPORT                #
+#######################################################################
+
+#######################################################################
+#              Set Dynamic Libraries we need to link against          #
+#######################################################################
+set(EXTRA_IMAGES_DYNAMIC_LIBRARIES ${JPEG_LIBRARIES}
+        ${PNG_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${WEBP_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${TIFF_LIBRARIES}
+        ${JP2K_LIBRARIES}
+        ${GIF_LIBRARIES}
+        ${LibArchive_LIBRARIES}
+        ${CURL_LIBRARIES}
+)
+
+
+
+##########################################################################
+#                           Prepare For Static Build                     #
+##########################################################################
+
+cmake_host_system_information(RESULT N_CORES QUERY NUMBER_OF_LOGICAL_CORES)
+if(N_CORES EQUAL 0)
+    message(WARNING "Unable to query core numbers. setting to 1")
+    set(N_PROC 1)
+elseif (N_CORES GREATER 1)
+    math(EXPR N_PROC "${N_CORES} - 1" OUTPUT_FORMAT DECIMAL)
+else ()
+    set(N_PROC ${N_CORES})
+endif ()
+
+message(STATUS "${N_CORES} Logical Cores Available using ${N_PROC}")
+
+##########################################################################
+#                          Leptonica External Static Build               #
+##########################################################################
+FetchContent_Populate(leptonicaPopulate
+        GIT_REPOSITORY https://github.com/DanBloomberg/leptonica.git
+        GIT_TAG        1.82.0
+        SOURCE_DIR "${LEPTONICA_SRC_DIR}"
+)
+
+
+set(LEPTONICA_BUILD_ARTIFACTS_DIR "${LEPTONICA_SRC_DIR}/build")
+file(MAKE_DIRECTORY ${LEPTONICA_BUILD_ARTIFACTS_DIR})
+
+if(NOT LEPTONICA_LIB_BUILD)
+    message(STATUS "Leptonica library not built. Building")
+    execute_process(COMMAND ${CMAKE_COMMAND} ".." "-DCMAKE_INSTALL_PREFIX='${LOCAL_FAKEROOT_INSTALL_PREFIX}'"
+            WORKING_DIRECTORY "${LEPTONICA_BUILD_ARTIFACTS_DIR}")
+    execute_process(COMMAND ${CMAKE_COMMAND}  "--build" "." "--parallel" "${N_PROC}"
+            WORKING_DIRECTORY "${LEPTONICA_BUILD_ARTIFACTS_DIR}")
+    execute_process(COMMAND ${CMAKE_COMMAND} "--install" "."
+            WORKING_DIRECTORY "${LEPTONICA_BUILD_ARTIFACTS_DIR}"
+            RESULT_VARIABLE LEPTONICA_BUILD_RESULT)
+
+    if(${LEPTONICA_BUILD_RESULT} EQUAL 0)
+        message(STATUS "Built leptonica successfully")
+        set(LEPTONICA_LIB_BUILD ON CACHE BOOL "" FORCE)
+    endif ()
+else ()
+    message(STATUS "Leptonica library built. Skipping")
+endif ()
+
+
+
+
+set(leptonica_INCLUDE_DIRS  "${LOCAL_FAKEROOT_INSTALL_INCLUDE_DIR}/leptonica")
+set(leptonica_DIR  "${LOCAL_FAKEROOT_INSTALL_LIBRARY_DIR}/cmake/leptonica")
+include_directories(${leptonica_INCLUDE_DIRS} ${LOCAL_FAKEROOT_INSTALL_INCLUDE_DIR})
+
+
+##########################################################################
+#                          Tesseract External Static Build               #
+##########################################################################
+
+FetchContent_Populate(tesseractPopulate
+        GIT_REPOSITORY https://github.com/tesseract-ocr/tesseract.git
+        GIT_TAG        5.1.0
+        SOURCE_DIR "${TESSERACT_SRC_DIR}"
+        TEST_COMMAND ""
+)
+
+set(TESSERACT_BUILD_ARTIFACTS_DIR "${TESSERACT_SRC_DIR}/build")
+file(MAKE_DIRECTORY ${TESSERACT_BUILD_ARTIFACTS_DIR})
+
+if(NOT TESSERACT_LIB_BUILT)
+    message(STATUS "Tesseract library not built. initiating build")
+    execute_process(COMMAND ${CMAKE_COMMAND} ".."  "-DCMAKE_INSTALL_PREFIX='${LOCAL_FAKEROOT_INSTALL_PREFIX}'" "-DLeptonica_DIR='${leptonica_DIR}'" "-DLeptonica_FOUND=true"
+            WORKING_DIRECTORY ${TESSERACT_BUILD_ARTIFACTS_DIR}
+    )
+    execute_process(COMMAND ${CMAKE_COMMAND}  "--build" "." "--parallel" "${N_PROC}"
+            WORKING_DIRECTORY ${TESSERACT_BUILD_ARTIFACTS_DIR}
+    )
+
+    execute_process(COMMAND ${CMAKE_COMMAND} "--install" "."
+            WORKING_DIRECTORY ${TESSERACT_BUILD_ARTIFACTS_DIR}
+            RESULT_VARIABLE TESSERACT_BUILD_RESULT
+    )
+    if(${TESSERACT_BUILD_RESULT} EQUAL 0)
+        message(STATUS "Built tessaract successfully")
+        set(TESSERACT_LIB_BUILT ON CACHE BOOL "" FORCE)
+    endif ()
+else ()
+    message(STATUS "Tesseract already built. skipping")
+endif ()
+
+
+set(tesseract_INCLUDE_DIRS  "${LOCAL_FAKEROOT_INSTALL_INCLUDE_DIR}/tesseract")
+include_directories(${tesseract_INCLUDE_DIRS})
+
+add_library(leptonica STATIC IMPORTED)
+set_target_properties(leptonica PROPERTIES
+        IMPORTED_LOCATION "${LOCAL_FAKEROOT_INSTALL_LIBRARY_DIR}/libleptonica.a"
+        INTERFACE_INCLUDE_DIRECTORIES "${leptonica_INCLUDE_DIRS}"
+)
+
+add_library(tesseract STATIC IMPORTED)
+set_target_properties(tesseract PROPERTIES
+        IMPORTED_LOCATION "${LOCAL_FAKEROOT_INSTALL_LIBRARY_DIR}/libtesseract.a"
+        INTERFACE_INCLUDE_DIRECTORIES "${tesseract_INCLUDE_DIRS}"
+        PUBLIC_INCLUDE_DIRECTORIES "${leptonica_INCLUDE_DIRS}"
+)
+##########################################################################
+#                  Link Tesseract to to static leptonica  lib            #
+##########################################################################
+target_link_libraries(tesseract INTERFACE leptonica)
+
+##########################################################################
+#                   Add TessData Leaning files for TESSDATA_PREFIX      #
+#                    This will only be achieved On Build                #
+##########################################################################
+
+ExternalProject_Add(tesseract-traineddata
+        GIT_REPOSITORY https://github.com/tesseract-ocr/tessdata_fast.git
+        GIT_TAG        4.1.0
+        SOURCE_DIR "${TESSDATA_DIR}"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        UPDATE_COMMAND ""
+        TEST_COMMAND ""
+        INSTALL_COMMAND ""
+)
+
+
+##########################################################################
+#                  Provide Targets for use by CMake File                 #
+#                  that is going to import this file.                    #
+##########################################################################
+set(Tesseract_STATICLIB_TARGET tesseract)
+set(Leptonica_STATICLIB_TARGET leptonica)
+##########################################################################
+#                 Set TESSDATA_PREFIX                                    #
+##########################################################################


### PR DESCRIPTION
* Modify CMakeLists.txt	to dynamically choose wether or	not we want to use the Dockerfile
 * If leptonica	or tesseract are not found they are fetched and	a static link is triggered
 * dockerless build can	also be	forced with -DDOCKERLESS_BUILD during cmake config
* Add new .cmake file to group new funcionality away from main CMakeLists
* Modify Readme.md to reflect new changes